### PR TITLE
Looking to add more columns

### DIFF
--- a/R/download_catch_rates.R
+++ b/R/download_catch_rates.R
@@ -70,7 +70,7 @@ download_catch_rates = function( survey="Eastern_Bering_Sea", add_zeros=TRUE, sp
   ########################
   # Obtain data
   ########################
-
+	# RDB wants to add more columns to what's returned (e.g., depth)
   # West Coast groundfish bottom trawl survey
   # https://www.nwfsc.noaa.gov/data/
   if( survey=="WCGBTS" ){


### PR DESCRIPTION
Right now I haven't changed anything, just added a comment which indicates my intention. As a matter of fact, the primary purpose of this PR is to indicate intention.

I want more columns returned. I'm working with the West Coast Bottom Trawl Survey, so I'll start there. How to handle flexible column returns while still providing reasonable defaults is not something I think I've perfected. But it is something that I've attempted w/ success in personal packages.

For an example of how I deal with flexible column returns, see: https://github.com/rBatt/trawlData/blob/master/R/clean.trimCol.R Looking at that, I'm noticing that I didn't complete my own example (sorry!). However, the c.add and c.drop column are what to focus on. Basically, there's a default set of columns to return. You can add any candidate column via `c.add`, and remove any default via `c.drop`. To make the recommendation truly useful, you just have to make sure to not include too many or too few columns, which I think you have in your current function.

To start, I will just add more columns to be returned. Then I might try to add a `c.add` argument to the parent function that is ignored for all cases except WCBTS.

The extra columns I add depends on what is used by a project @mpinsky leads; particularly a [large all-purpose script](https://github.com/mpinsky/OceanAdapt/blob/master/complete_r_script.R), which fuels OceanAdapt, requires variables like "depth".

Actual changes and commits will start showing up later today. I'm working on this project this week.

Thanks for making this package, very helpful!

