### PR TITLE
updated naming options, fixed query for WCHGL, fixed years in other s…

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^\.git$
 cran-comments.md
 ^\.travis\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
 *.dll
 *.so
+.Rproj.user
+*.Rproj

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,7 +8,7 @@
   packageStartupMessage("This package is in development, and comes with no implied or explicit guaruntee of accuracy")
   packageStartupMessage("Interested users should read the code and consult the survey-specific websites being queried")
   packageStartupMessage("###########################################################################################")
-  if( !"icesDatras" %in% installed.packages()[,1] ){
+  if( !"icesDatras" %in% utils::installed.packages()[,1] ){
     print("Installing package: icesDatras...")
     devtools::install_github('ices-tools-prod/icesDatras', ref="1.1-1")
   }else{

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,7 +12,7 @@
     print("Installing package: icesDatras...")
     devtools::install_github('ices-tools-prod/icesDatras', ref="1.1-1")
   }else{
-    Data = data( package="icesDatras", verbose=FALSE )
+    Data = utils::data( package="icesDatras", verbose=FALSE )
     if( !("aphia" %in% Data$results[,'Item']) ) stop("Must use `icesDatras` version `1.1=1` from GitHub")
   }
 }


### PR DESCRIPTION
OK, there were a few things going on but I think this should do it. 

The main problem was that some of the downloaded files had a header row inserted  in the data from a page break (e.g. the word "LONGITUDE" in row 49999 of column "LONGITUDE"), resulting in numeric columns like longitude being stored as characters. This was then breaking some calls to `sum` later on.  I added a small chunk to identify and fix the problem. 

I also updated the WCGHL survey query, which seemed to be out of date, updated the year queries for some of the other surveys, and fixed the suggested name for the GOABTS survey from "Gulf of Alaska" to "Gulf_of_Alaska"

Tested EBSBTS, AIBTS, GOABTS, WCGBTS, WCGHL for 50 species over all years and confirmed that the updated download_catch_rates works for all of them