### PR TITLE
Fix other queries

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^\.git$
 cran-comments.md
 ^\.travis\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.o
 *.dll
 *.so
+*.Rproj.user
+.Rproj
+*.Rproj


### PR DESCRIPTION
Fixes #9 

I converted @James-Thorson 's fix from #8 (thanks for tackling that) to a function and added the new function to each of the queries, confirmed that behavior remains the same. 

Also updated the column names for the WCGHL query, confirmed they work. 

Also WCGBTS 2016 had no data 

Running top 50 species for EBSBTS, GOABTS, AIBTS, WCGBTS, and WCGHL confirms that all five queries function. 

The reason that prior to #8 there were way too many observations per species (and low encounter rates for things like alaska pollock) was that the header problem was causing random white spaces to be entered in the haul ID, making way too many unique TowID variables (e.g. "18", "18   " were both being generated). Following this fix, encounter rates look good 

![image](https://user-images.githubusercontent.com/8096183/36701881-c8c81424-1b09-11e8-82ef-d43cfaf430a4.png)

Sample sizes also look right

![image](https://user-images.githubusercontent.com/8096183/36702144-bb8b06e4-1b0a-11e8-93aa-b713215aa66b.png)

