### PR TITLE
updated WCGBTS years from 2003:2015 to 2003:2018

### DIFF
--- a/R/download_catch_rates.R
+++ b/R/download_catch_rates.R
@@ -91,7 +91,7 @@ download_catch_rates = function( survey="Eastern_Bering_Sea", add_zeros=TRUE, sp
   # https://www.nwfsc.noaa.gov/data/
   if( survey=="WCGBTS" ){
     # Names of pieces
-    files = 2003:2015
+    files = 2003:2018
     Vars = c("field_identified_taxonomy_dim$scientific_name", "date_dim$year", "tow",
       "latitude_dd", "longitude_dd", "centroid_id", "area_swept_ha_der",
       "cpue_kg_per_ha_der", "cpue_numbers_per_ha_der",


### PR DESCRIPTION
Updating years fetched for the WCGBTS survey. I checked that Downloaded_data has a complete set of data for 2018; the number of rows and average CPUE is comparable to previous years, so I don't think any data is missing. Data through 2018 (and some of 2019) is also available interactively at https://www.nwfsc.noaa.gov/data/